### PR TITLE
Add checksum calculation to relevant barcode types

### DIFF
--- a/barcode.go
+++ b/barcode.go
@@ -17,4 +17,5 @@ type Barcode interface {
 	Metadata() Metadata
 	// the data that was encoded in this barcode
 	Content() string
+	CheckSum() int
 }

--- a/codabar/encoder.go
+++ b/codabar/encoder.go
@@ -45,5 +45,5 @@ func Encode(content string) (barcode.Barcode, error) {
 		}
 		resBits.AddBit(encodingTable[r]...)
 	}
-	return utils.New1DCode("Codabar", content, resBits), nil
+	return utils.New1DCode("Codabar", content, resBits, 0), nil
 }

--- a/code128/encode.go
+++ b/code128/encode.go
@@ -116,5 +116,5 @@ func Encode(content string) (barcode.Barcode, error) {
 	}
 	result.AddBit(encodingTable[sum%103]...)
 	result.AddBit(encodingTable[stopSymbol]...)
-	return utils.New1DCode("Code 128", content, result), nil
+	return utils.New1DCode("Code 128", content, result, sum%103), nil
 }

--- a/code39/encoder.go
+++ b/code39/encoder.go
@@ -3,6 +3,7 @@ package code39
 
 import (
 	"errors"
+	"strconv"
 	"strings"
 
 	"github.com/boombuler/barcode"
@@ -143,5 +144,9 @@ func Encode(content string, includeChecksum bool, fullASCIIMode bool) (barcode.B
 		result.AddBit(info.data...)
 	}
 
-	return utils.New1DCode("Code 39", content, result), nil
+	checkSum, err := strconv.ParseInt(getChecksum(content), 10, 64)
+	if err != nil {
+		checkSum = 0
+	}
+	return utils.New1DCode("Code 39", content, result, int(checkSum)), nil
 }

--- a/datamatrix/datamatrixcode.go
+++ b/datamatrix/datamatrixcode.go
@@ -40,6 +40,10 @@ func (c *datamatrixCode) At(x, y int) color.Color {
 	return color.White
 }
 
+func (c *datamatrixCode) CheckSum() int {
+	return 0
+}
+
 func (c *datamatrixCode) get(x, y int) bool {
 	return c.GetBit(x*c.Rows + y)
 }

--- a/ean/encoder.go
+++ b/ean/encoder.go
@@ -159,25 +159,28 @@ func encodeEAN13(code string) *utils.BitList {
 
 // Encode returns a EAN 8 or EAN 13 barcode for the given code
 func Encode(code string) (barcode.Barcode, error) {
+	var checkSum int
 	if len(code) == 7 || len(code) == 12 {
 		code += string(calcCheckNum(code))
+		checkSum = utils.RuneToInt(calcCheckNum(code))
 	} else if len(code) == 8 || len(code) == 13 {
 		check := code[0 : len(code)-1]
 		check += string(calcCheckNum(check))
 		if check != code {
 			return nil, errors.New("checksum missmatch")
 		}
+		checkSum = utils.RuneToInt(rune(code[len(code)-1]))
 	}
 
 	if len(code) == 8 {
 		result := encodeEAN8(code)
 		if result != nil {
-			return utils.New1DCode("EAN 8", code, result), nil
+			return utils.New1DCode("EAN 8", code, result, checkSum), nil
 		}
 	} else if len(code) == 13 {
 		result := encodeEAN13(code)
 		if result != nil {
-			return utils.New1DCode("EAN 13", code, result), nil
+			return utils.New1DCode("EAN 13", code, result, checkSum), nil
 		}
 	}
 	return nil, errors.New("invalid ean code data")

--- a/qr/qrcode.go
+++ b/qr/qrcode.go
@@ -46,6 +46,10 @@ func (qr *qrcode) Set(x, y int, val bool) {
 	qr.data.SetBit(x*qr.dimension+y, val)
 }
 
+func (qr *qrcode) CheckSum() int {
+	return 0
+}
+
 func (qr *qrcode) calcPenalty() uint {
 	return qr.calcPenaltyRule1() + qr.calcPenaltyRule2() + qr.calcPenaltyRule3() + qr.calcPenaltyRule4()
 }

--- a/scaledbarcode.go
+++ b/scaledbarcode.go
@@ -36,6 +36,10 @@ func (bc *scaledBarcode) At(x, y int) color.Color {
 	return bc.wrapperFunc(x, y)
 }
 
+func (bc *scaledBarcode) CheckSum() int {
+	return bc.wrapped.CheckSum()
+}
+
 // Scale returns a resized barcode with the given width and height.
 func Scale(bc Barcode, width, height int) (Barcode, error) {
 	switch bc.Metadata().Dimensions {

--- a/twooffive/encoder.go
+++ b/twooffive/encoder.go
@@ -134,5 +134,5 @@ func Encode(content string, interleaved bool) (barcode.Barcode, error) {
 	if interleaved {
 		kindTxt = " (interleaved)"
 	}
-	return utils.New1DCode("2 of 5"+kindTxt, content, resBits), nil
+	return utils.New1DCode("2 of 5"+kindTxt, content, resBits, -1), nil
 }

--- a/utils/base1dcode.go
+++ b/utils/base1dcode.go
@@ -10,8 +10,9 @@ import (
 
 type base1DCode struct {
 	*BitList
-	kind    string
-	content string
+	kind     string
+	content  string
+	checksum int
 }
 
 func (c *base1DCode) Content() string {
@@ -37,7 +38,11 @@ func (c *base1DCode) At(x, y int) color.Color {
 	return color.White
 }
 
+func (c *base1DCode) CheckSum() int {
+	return c.checksum
+}
+
 // New1DCode creates a new 1D barcode where the bars are represented by the bits in the bars BitList
-func New1DCode(codeKind, content string, bars *BitList) barcode.Barcode {
-	return &base1DCode{bars, codeKind, content}
+func New1DCode(codeKind, content string, bars *BitList, checksum int) barcode.Barcode {
+	return &base1DCode{bars, codeKind, content, checksum}
 }


### PR DESCRIPTION
This is a stab at making checksums available in barcodes for which they are relevant. I've gone with returning a 0 for those cases where the checksum wouldn't make sense. Fixes #7 