### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-##Introduction##
+## Introduction ##
 This is a package for GO which can be used to create different types of barcodes.
 
-##Supported Barcode Types##
+## Supported Barcode Types ##
 * Aztec Code
 * Codabar
 * Code 128
@@ -12,7 +12,7 @@ This is a package for GO which can be used to create different types of barcodes
 * QR Codes
 * 2 of 5
 
-##Documentation##
+## Documentation ##
 See [GoDoc](https://godoc.org/github.com/boombuler/barcode)
 
 To create a barcode use the Encode function from one of the subpackages.


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
