### PR TITLE
added constants for barcode types

### DIFF
--- a/aztec/azteccode.go
+++ b/aztec/azteccode.go
@@ -24,7 +24,7 @@ func (c *aztecCode) Content() string {
 }
 
 func (c *aztecCode) Metadata() barcode.Metadata {
-	return barcode.Metadata{"Aztec", 2}
+	return barcode.Metadata{barcode.TypeAztec, 2}
 }
 
 func (c *aztecCode) ColorModel() color.Model {

--- a/barcode.go
+++ b/barcode.go
@@ -2,6 +2,21 @@ package barcode
 
 import "image"
 
+const (
+	TypeAztec           = "Aztec"
+	TypeCodabar         = "Codabar"
+	TypeCode128         = "Code 128"
+	TypeCode39          = "Code 39"
+	TypeCode93          = "Code 93"
+	TypeDataMatrix      = "DataMatrix"
+	TypeEAN8            = "EAN 8"
+	TypeEAN13           = "EAN 13"
+	TypePDF             = "PDF417"
+	TypeQR              = "QR Code"
+	Type2of5            = "2 of 5"
+	Type2of5Interleaved = "2 of 5 (interleaved)"
+)
+
 // Contains some meta information about a barcode
 type Metadata struct {
 	// the name of the barcode kind

--- a/codabar/encoder.go
+++ b/codabar/encoder.go
@@ -45,5 +45,5 @@ func Encode(content string) (barcode.Barcode, error) {
 		}
 		resBits.AddBit(encodingTable[r]...)
 	}
-	return utils.New1DCode("Codabar", content, resBits), nil
+	return utils.New1DCode(barcode.TypeCodabar, content, resBits), nil
 }

--- a/code128/encode.go
+++ b/code128/encode.go
@@ -180,7 +180,7 @@ func Encode(content string) (barcode.BarcodeIntCS, error) {
 	sum = sum % 103
 	result.AddBit(encodingTable[sum]...)
 	result.AddBit(encodingTable[stopSymbol]...)
-	return utils.New1DCodeIntCheckSum("Code 128", content, result, sum), nil
+	return utils.New1DCodeIntCheckSum(barcode.TypeCode128, content, result, sum), nil
 }
 
 func EncodeWithoutChecksum(content string) (barcode.Barcode, error) {
@@ -199,5 +199,5 @@ func EncodeWithoutChecksum(content string) (barcode.Barcode, error) {
 		result.AddBit(encodingTable[idx]...)
 	}
 	result.AddBit(encodingTable[stopSymbol]...)
-	return utils.New1DCode("Code 128", content, result), nil
+	return utils.New1DCode(barcode.TypeCode128, content, result), nil
 }

--- a/code39/encoder.go
+++ b/code39/encoder.go
@@ -148,5 +148,5 @@ func Encode(content string, includeChecksum bool, fullASCIIMode bool) (barcode.B
 	if err != nil {
 		checkSum = 0
 	}
-	return utils.New1DCodeIntCheckSum("Code 39", content, result, int(checkSum)), nil
+	return utils.New1DCodeIntCheckSum(barcode.TypeCode39, content, result, int(checkSum)), nil
 }

--- a/code93/encoder.go
+++ b/code93/encoder.go
@@ -102,7 +102,7 @@ func Encode(content string, includeChecksum bool, fullASCIIMode bool) (barcode.B
 	}
 	result.AddBit(true)
 
-	return utils.New1DCode("Code 93", content, result), nil
+	return utils.New1DCode(barcode.TypeCode93, content, result), nil
 }
 
 func getChecksum(content string, maxWeight int) rune {

--- a/datamatrix/datamatrixcode.go
+++ b/datamatrix/datamatrixcode.go
@@ -1,10 +1,11 @@
 package datamatrix
 
 import (
-	"github.com/boombuler/barcode"
-	"github.com/boombuler/barcode/utils"
 	"image"
 	"image/color"
+
+	"github.com/boombuler/barcode"
+	"github.com/boombuler/barcode/utils"
 )
 
 type datamatrixCode struct {
@@ -22,7 +23,7 @@ func (c *datamatrixCode) Content() string {
 }
 
 func (c *datamatrixCode) Metadata() barcode.Metadata {
-	return barcode.Metadata{"DataMatrix", 2}
+	return barcode.Metadata{barcode.TypeDataMatrix, 2}
 }
 
 func (c *datamatrixCode) ColorModel() color.Model {

--- a/ean/encoder.go
+++ b/ean/encoder.go
@@ -175,12 +175,12 @@ func Encode(code string) (barcode.BarcodeIntCS, error) {
 	if len(code) == 8 {
 		result := encodeEAN8(code)
 		if result != nil {
-			return utils.New1DCodeIntCheckSum("EAN 8", code, result, checkSum), nil
+			return utils.New1DCodeIntCheckSum(barcode.TypeEAN8, code, result, checkSum), nil
 		}
 	} else if len(code) == 13 {
 		result := encodeEAN13(code)
 		if result != nil {
-			return utils.New1DCodeIntCheckSum("EAN 13", code, result, checkSum), nil
+			return utils.New1DCodeIntCheckSum(barcode.TypeEAN13, code, result, checkSum), nil
 		}
 	}
 	return nil, errors.New("invalid ean code data")

--- a/pdf417/pdfcode.go
+++ b/pdf417/pdfcode.go
@@ -15,7 +15,7 @@ type pdfBarcode struct {
 }
 
 func (c *pdfBarcode) Metadata() barcode.Metadata {
-	return barcode.Metadata{"PDF417", 2}
+	return barcode.Metadata{barcode.TypePDF, 2}
 }
 
 func (c *pdfBarcode) Content() string {

--- a/qr/qrcode.go
+++ b/qr/qrcode.go
@@ -20,7 +20,7 @@ func (qr *qrcode) Content() string {
 }
 
 func (qr *qrcode) Metadata() barcode.Metadata {
-	return barcode.Metadata{"QR Code", 2}
+	return barcode.Metadata{barcode.TypeQR, 2}
 }
 
 func (qr *qrcode) ColorModel() color.Model {

--- a/twooffive/encoder.go
+++ b/twooffive/encoder.go
@@ -130,9 +130,9 @@ func Encode(content string, interleaved bool) (barcode.Barcode, error) {
 
 	resBits.AddBit(mode.end...)
 
-	kindTxt := ""
 	if interleaved {
-		kindTxt = " (interleaved)"
+		return utils.New1DCode(barcode.Type2of5Interleaved, content, resBits), nil
+	} else {
+		return utils.New1DCode(barcode.Type2of5, content, resBits), nil
 	}
-	return utils.New1DCode("2 of 5"+kindTxt, content, resBits), nil
 }


### PR DESCRIPTION
Allows for easy checking of barcode types:

So:

```
if qr.Metadata().CodeKind == "QR Code" {
    // Do stuff here
}
```

Can now be:

```
if qr.Metadata().CodeKind == barcode.TypeQR {
    // Do stuff here
}
```

Similar in design to the `net/http` package's `http.StatusOK`.
