### PR TITLE
Trim whitespace for 1D barcode

### DIFF
--- a/scaledbarcode.go
+++ b/scaledbarcode.go
@@ -112,7 +112,9 @@ func scale1DCode(bc Barcode, width, height int) (Barcode, error) {
 	if factor <= 0 {
 		return nil, fmt.Errorf("can not scale barcode to an image smaller than %dx1", orgWidth)
 	}
-	offsetX := (width - (orgWidth * factor)) / 2
+
+	width = (orgWidth * factor) + 2
+	offsetX := 1
 
 	wrap := func(x, y int) color.Color {
 		if x < offsetX {


### PR DESCRIPTION
remove long whitespace for 1D barcode 