### PR TITLE
Correct a few format string issues

### DIFF
--- a/utils/runeint_test.go
+++ b/utils/runeint_test.go
@@ -4,7 +4,7 @@ import "testing"
 
 func Test_RuneToIntIntToRune(t *testing.T) {
 	if IntToRune(0) != '0' {
-		t.Errorf("failed IntToRune(0) returned %d", string(IntToRune(0)))
+		t.Errorf("failed IntToRune(0) returned %d", IntToRune(0))
 	}
 	if IntToRune(9) != '9' {
 		t.Errorf("failed IntToRune(9) returned %d", IntToRune(9))
@@ -13,12 +13,12 @@ func Test_RuneToIntIntToRune(t *testing.T) {
 		t.Errorf("failed IntToRune(10) returned %d", IntToRune(10))
 	}
 	if RuneToInt('0') != 0 {
-		t.Error("failed RuneToInt('0') returned %d", RuneToInt(0))
+		t.Errorf("failed RuneToInt('0') returned %d", RuneToInt(0))
 	}
 	if RuneToInt('9') != 9 {
-		t.Error("failed RuneToInt('9') returned %d", RuneToInt(9))
+		t.Errorf("failed RuneToInt('9') returned %d", RuneToInt(9))
 	}
 	if RuneToInt('F') != -1 {
-		t.Error("failed RuneToInt('F') returned %d", RuneToInt('F'))
+		t.Errorf("failed RuneToInt('F') returned %d", RuneToInt('F'))
 	}
 }


### PR DESCRIPTION
I maintain a Fedora package of barcode, and a recent update to go 1.10 (slated to appear in Fedora 28) triggered a few test failures due to `go vet` being [run by default now](https://golang.org/doc/go1.10#test). This patch cleans up the issues that were automatically picked up.