### PR TITLE
Use golangci-lint to enforce linting and formatting rules

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,0 +1,31 @@
+name: Lint
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+permissions:
+  contents: read
+
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: stable
+
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v8
+        with:
+          version: v2.1
+          # Show only new issues until the entire repository
+          # is compliant with the new linting rules.
+          only-new-issues: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,23 @@
+# Configuration of formatting and linting using https://golangci-lint.run/.
+version: "2"
+
+linters:
+  default: none
+  enable:
+    - errcheck
+    - govet
+    - ineffassign
+    - staticcheck
+    - unused
+
+formatters:
+  enable:
+    - gofmt
+    - goimports
+
+issues:
+  # Show only new issues created after the introduction of the linter.
+  new-from-rev: ea5ac7e13561f6334938261321e13a725d1c0180
+
+  # Show issues in any part of update files (requires new-from-rev or new-from-patch).
+  whole-files: true


### PR DESCRIPTION
This is motivated by #89 to document the target baseline for linting. It intentionally avoids enforcing linting for changes prior to the introduction of this configuration so that the project can be incrementally brought in line.

Each linter is explicitly enabled so there are no surprises if the defaults are changed.

Only simple formatters are included since the needs of this project are relatively simple.

The included GitHub Actions workflow derives from the [recommendation][1] to run a separate linting job in parallel with other jobs (i.e. tests).

[1]: https://github.com/golangci/golangci-lint-action?tab=readme-ov-file#how-to-use